### PR TITLE
fix issue in dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,4 @@ lib/
 
 kubernetes/**
 .vscode
-config/local.json
-config/dev.json
 config/prod.json
-config/production.json

--- a/config/default.json
+++ b/config/default.json
@@ -1,4 +1,6 @@
 {
+  "#WARNING": "DO NOT WRITE any secrets here, just write env variable names in the vlaues like below",
+  "#Development": "for development config, fill config/development.json, and dont commit secrets to git",
   "host": "localhost",
   "port": 3030,
   "public": "../public/",
@@ -32,9 +34,9 @@
     "oauth": {
       "redirect": "/",
       "auth0": {
-        "key": "<auth0 oauth key>",
-        "secret": "<auth0 oauth secret>",
-        "subdomain": "<auth0 subdomain>"
+        "key": "AUTH0_KEY",
+        "secret": "AUTH0_SECRET",
+        "subdomain": "AUTH0_SUBDOMAIN"
       },
       "google": {
         "key": "GOOGLE_CLIENT_ID",
@@ -51,8 +53,8 @@
         "scope": ["email, public_profile"]
       },
       "twitter": {
-        "key": "<twitter oauth key>",
-        "secret": "<twitter oauth secret>"
+        "key": "TWITTER_KEY",
+        "secret": "TWITTER_SECRET"
       },
       "github": {
         "key": "GITHUB_CLIENT_ID",

--- a/config/production.json
+++ b/config/production.json
@@ -1,5 +1,10 @@
 {
-  "host": "xrchat-server-app.feathersjs.com",
+  "#WARNING": "DO NOT WRITE any secrets here, just write env variable names in the vlaues like below",
+  "#Development": "for development config, fill config/default.json, and dont commit secrets to git",
+  "host": "HOST",
   "port": "PORT",
+  "authentication": {
+    "secret": "AUTH_SECRET"
+  },
   "mysql": "MYSQL_URL"
 }


### PR DESCRIPTION
Fixes a docker issue ommitting env vars decalred in production.json in dockerignore
I think @barankyle did it to protect production.json secrets. but I added a comment to avoid people putting secrets there

it would be nice to pull production.json from a k8s configMap, but it can't happen becae configMaps map to volumes
also we can eventually just use NODE_CONFIG="{config json content}" if config grows