### PR TITLE
Added UUID generation hook. Updated how remote resource paths are generated to prevent collisions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@types/lodash": "^4.14.150",
     "@types/multer": "^1.4.3",
     "@types/nodemailer": "^6.4.0",
+    "@types/uuid": "^7.0.3",
     "acorn": "^7.1.1",
     "apollo-server": "^2.12.0",
     "apollo-server-express": "^2.12.0",

--- a/src/hooks/add-upload-path.ts
+++ b/src/hooks/add-upload-path.ts
@@ -1,0 +1,10 @@
+import { Hook, HookContext } from '@feathersjs/feathers'
+import * as path from 'path'
+import getBasicMimetype from "../util/get-basic-mimetype";
+
+export default (options = {}): Hook => {
+  return async (context: HookContext) => {
+    context.params.uploadPath = context.params.uploadPath ? context.params.uploadPath : path.join(context.params.uuid, getBasicMimetype(context.params.mime_type))
+    return context
+  }
+}

--- a/src/hooks/add-uuid.ts
+++ b/src/hooks/add-uuid.ts
@@ -1,0 +1,9 @@
+import { Hook, HookContext } from '@feathersjs/feathers'
+import { v1 } from 'uuid'
+
+export default (options = {}): Hook => {
+  return async (context: HookContext) => {
+    context.params.uuid = context.params.uuid ? context.params.uuid : v1()
+    return context
+  }
+}

--- a/src/hooks/convert-video.ts
+++ b/src/hooks/convert-video.ts
@@ -71,7 +71,7 @@ export default async (context: any): Promise<void> => {
   }
 
   if (fileId.length > 0) {
-    const s3Key = path.join('video', context.params.videoSource, fileId, dashManifestName)
+    const s3Key = path.join('public', context.params.videoSource, fileId, 'video', dashManifestName)
     s3BlobStore.exists({
       key: (s3Key)
     }, async (err: any, exists: any) => {
@@ -140,7 +140,7 @@ export default async (context: any): Promise<void> => {
         }
       } else {
         console.log('File already existed, just making DB entries and updating URL')
-        const s3Path = path.join('video', context.params.videoSource, fileId)
+        const s3Path = path.join('public', context.params.videoSource, fileId, 'video')
         const bucketObjects = await new Promise((resolve, reject) => {
           s3.listObjects({
             Bucket: s3BlobStore.bucket,
@@ -233,7 +233,7 @@ async function uploadFile (localFilePath: string, fileId: string, context: any, 
 
             localContext.params.mime_type = mimetype
             localContext.params.storageProvider = new StorageProvider()
-            localContext.params.uploadPath = path.join('video', context.params.videoSource, fileId)
+            localContext.params.uploadPath = path.join('public', context.params.videoSource, fileId, 'video')
 
             if (/.mpd/.test(file)) {
               localContext.params.skipResourceCreation = true

--- a/src/hooks/create-static-resource.ts
+++ b/src/hooks/create-static-resource.ts
@@ -24,6 +24,9 @@ export default (options = {}): Hook => {
         (resourceData as any).parentResourceId = context.params.parentResourceId
       }
       (resourceData as any).type = getBasicMimetype(resourceData.mime_type)
+      if (context.params.uuid && context.params.parentResourceId == null) {
+        (resourceData as any).id = context.params.uuid
+      }
       context.result = await context.app.service('static-resource').create(resourceData)
     }
 

--- a/src/services/static-resource-type/static-resource-type.seed.ts
+++ b/src/services/static-resource-type/static-resource-type.seed.ts
@@ -1,6 +1,6 @@
 export const seed = {
   disabled: (process.env.FORCE_DB_REFRESH !== 'true'),
-  delete: true,
+  delete: (process.env.FORCE_DB_REFRESH === 'true'),
   path: 'static-resource-type',
   randomize: false,
   templates: [

--- a/src/services/static-resource/static-resource.hooks.ts
+++ b/src/services/static-resource/static-resource.hooks.ts
@@ -16,6 +16,7 @@ export default {
           const name = context.data.name ?? file.name
           context.data = { uri: uri, mimeType: mimeType, name: name }
         }
+        return context
       }
     ],
     update: [],

--- a/src/services/upload/upload.hooks.ts
+++ b/src/services/upload/upload.hooks.ts
@@ -1,4 +1,6 @@
 import { disallow } from 'feathers-hooks-common'
+import addUUID from '../../hooks/add-uuid'
+import addUploadPath from '../../hooks/add-upload-path'
 
 // Don't remove this comment. It's needed to format import lines nicely.
 
@@ -14,7 +16,7 @@ export default {
     all: [],
     find: [disallow()],
     get: [disallow()],
-    create: [addUriToFile(), makeS3FilesPublic()],
+    create: [addUUID(), addUploadPath(), addUriToFile(), makeS3FilesPublic()],
     update: [disallow()],
     patch: [disallow()],
     remove: [disallow()]

--- a/src/services/upload/upload.service.ts
+++ b/src/services/upload/upload.service.ts
@@ -7,7 +7,6 @@ import blobService from 'feathers-blob'
 import { Application } from '../../declarations'
 import { Upload } from './upload.class'
 import hooks from './upload.hooks'
-import getBasicMimetype from '../../util/get-basic-mimetype'
 
 const multipartMiddleware = multer()
 
@@ -29,9 +28,6 @@ export default (app: Application): void => {
         req.feathers.mime_type = req.feathers.file.mimetype
         req.feathers.storageProvider = provider
         req.feathers.thumbnail = (req as any).files.thumbnail ? (req as any).files.thumbnail[0] : null
-        if (req.feathers.mime_type) {
-          req.feathers.uploadPath = getBasicMimetype(req.feathers.mime_type)
-        }
         next()
       }
     },


### PR DESCRIPTION
Upload service now generates UUID and uses it as an identifier for all
related resources. So, if a file is uploaded with a thumbnail, the
static-resource for the file will have that UUID, the stored path will
start with the UUID, and both the file and its thumbnail will be stored
under that UUID path, e.g. abcd1234/video/cool-video.mp4 and
abcd1234/image/cool-video-thumbnail.jpg

/video endpoint is still generating "public" videos, so they are all
grouped under the "UUID" of "public". Under that, it's now <service>/
<service-id>/<type>/<name>, e.g.
public/youtube/abcd1234_m/video/manifest.mpd.
This may change in the future once we implement a better way to indicate
public vs. private videos.