### PR TITLE
Fixed several incorrect references to identityProvider.type. 

### DIFF
--- a/src/hooks/hash-identity-provider-fields.ts
+++ b/src/hooks/hash-identity-provider-fields.ts
@@ -1,0 +1,10 @@
+import { Hook, HookContext } from '@feathersjs/feathers'
+import bcrypt from 'bcrypt'
+
+export default function (options = {}): Hook {
+  return async (context: HookContext) => {
+    const { data } = context
+    if (data?.password) { data.password = await bcrypt.hash(data.password, 10) }
+    return context
+  }
+}

--- a/src/models/identity-provider.model.ts
+++ b/src/models/identity-provider.model.ts
@@ -1,6 +1,5 @@
 import { Sequelize, DataTypes } from 'sequelize'
 import { Application } from '../declarations'
-import bcrypt from 'bcrypt'
 
 export default (app: Application): any => {
   const sequelizeClient: Sequelize = app.get('sequelizeClient')
@@ -18,10 +17,6 @@ export default (app: Application): any => {
     hooks: {
       beforeCount (options: any) {
         options.raw = true
-      },
-      async beforeCreate (options: any) {
-        options.dataValues.password = await bcrypt.hash(options.dataValues.password, 10)
-        options.dataValues.token = await bcrypt.hash(options.dataValues.token, 10)
       }
     },
     indexes: [

--- a/src/services/auth-management/auth-management.notifier.ts
+++ b/src/services/auth-management/auth-management.notifier.ts
@@ -17,7 +17,7 @@ export default (app: Application): any => {
       }
     },
     notifier: async (type: string, identityProvider: any): Promise<void> => {
-      if (identityProvider.type !== 'password') {
+      if (identityProvider.identityProviderType !== 'password') {
         return
       }
 

--- a/src/services/identity-provider-type/identity-provider-type.seed.ts
+++ b/src/services/identity-provider-type/identity-provider-type.seed.ts
@@ -5,7 +5,7 @@ export const seed = {
   randomize: false,
   templates:
         [
-          { iden: 'email' },
+          { type: 'email' },
           { type: 'sms' },
           { type: 'password' },
           { type: 'github' },

--- a/src/services/identity-provider/identity-provider.hooks.ts
+++ b/src/services/identity-provider/identity-provider.hooks.ts
@@ -3,6 +3,7 @@ import { hooks } from '@feathersjs/authentication-local'
 import { iff, isProvider, preventChanges } from 'feathers-hooks-common'
 import accountService from '../auth-management/auth-management.notifier'
 import { HookContext } from '@feathersjs/feathers'
+import hashIdentityProviderFields from '../../hooks/hash-identity-provider-fields'
 
 const verifyHooks = require('feathers-authentication-management').hooks
 // const { authenticate } = feathersAuthentication.hooks
@@ -20,7 +21,7 @@ const isPasswordAccountType = () => {
 
 const sendVerifyEmail = () => {
   return (context: any) => {
-    if (context.result?.type === 'password') {
+    if (context.result?.identityProviderType === 'password') {
       accountService(context.app).notifier('resendVerifySignup', context.result)
     }
     return context
@@ -29,7 +30,7 @@ const sendVerifyEmail = () => {
 
 export default {
   before: {
-    all: [],
+    all: [hashIdentityProviderFields()],
     find: [],
     get: [],
     create: [

--- a/src/services/magiclink/magiclink.class.ts
+++ b/src/services/magiclink/magiclink.class.ts
@@ -132,7 +132,7 @@ export class Magiclink implements ServiceMethods<Data> {
     const identityProviders = ((await identityProviderService.find({
       query: {
         token: token,
-        type: data.type
+        identityProviderType: data.type
       }
     })) as any).data
 
@@ -140,7 +140,7 @@ export class Magiclink implements ServiceMethods<Data> {
       identityProvider = await identityProviderService.create(
         {
           token: token,
-          type: data.type,
+          identityProviderType: data.type,
           userId: data.userId
         },
         params

--- a/src/services/user/user.class.ts
+++ b/src/services/user/user.class.ts
@@ -14,7 +14,6 @@ export class User extends Service {
 
   async find (params: Params): Promise<any> {
     const action = params.query?.action
-    console.log(params.query)
     if (action === 'withRelation') {
       const userId = params.query?.userId
 


### PR DESCRIPTION
It is now identityProvider.identityProviderType.

Removed hashing of identityProvider.token on creation. This broke a lot
of functionality that required looking up an identityProvider by token,
as well as password login's post-signup hook to send out the verify
email. There are probably some workarounds, but for now it's easier to
keep that as plaintext. The password, if it's present, is still hashed
via bcrypt.

Moved identityProvider hashing hook to separate file.