### PR TITLE
Video conversion fixes

### DIFF
--- a/src/hooks/create-static-resource.ts
+++ b/src/hooks/create-static-resource.ts
@@ -12,9 +12,9 @@ export default (options = {}): Hook => {
       url: data.uri || data.url,
       mime_type: data.mime_type || params.mime_type,
       metadata: data.metadata || body.metadata,
-      type: 'data'
+      staticResourceType: 'data'
     }
-    resourceData.type = data.type === 'user-thumbnail' || body.type === 'user-thumbnail' ? 'user-thumbnail' : getBasicMimetype(resourceData.mime_type)
+    resourceData.staticResourceType = data.type === 'user-thumbnail' || body.type === 'user-thumbnail' ? 'user-thumbnail' : getBasicMimetype(resourceData.mime_type)
     if (context.params.skipResourceCreation === true) {
       context.result = await context.app.service('static-resource').patch(context.params.patchId, {
         url: resourceData.url,
@@ -28,7 +28,7 @@ export default (options = {}): Hook => {
         (resourceData as any).id = context.params.uuid
       }
 
-      if (resourceData.type === 'user-thumbnail') {
+      if (resourceData.staticResourceType === 'user-thumbnail') {
         const existingThumbnails = await context.app.service('static-resource').find({
           query: {
             userId: body.userId,

--- a/src/hooks/upload-thumbnail-link.ts
+++ b/src/hooks/upload-thumbnail-link.ts
@@ -23,6 +23,7 @@ export default (options = {}): Hook => {
       context.params.mime_type = context.params.file.mimetype = 'image/' + extension
       context.data.name = context.params.file.originalname
       context.data.metadata = context.data.metadata ? context.data.metadata : {}
+      context.data.parentResourceId = context.params.parentResourceId
       context.params.uploadPath = context.params.uploadPath.replace('video', 'image')
       const uploadResult = await app.services.upload.create(context.data, context.params)
       const parent = await app.services['static-resource'].get(result.id)

--- a/src/hooks/upload-thumbnail-link.ts
+++ b/src/hooks/upload-thumbnail-link.ts
@@ -1,7 +1,7 @@
 import bent from 'bent'
 import { Hook, HookContext } from '@feathersjs/feathers'
 
-const fileRegex = /.([a-zA-Z0-9]+)$/
+const fileRegex = /\.([a-zA-Z0-9]+)(?=\?|$)/
 const getBuffer = bent('buffer')
 
 export default (options = {}): Hook => {

--- a/src/models/static-resource.model.ts
+++ b/src/models/static-resource.model.ts
@@ -15,7 +15,7 @@ export default (app: Application): any => {
       allowNull: false
     },
     description: {
-      type: DataTypes.STRING,
+      type: DataTypes.STRING(1023),
       allowNull: true
     },
     url: {

--- a/src/services/static-resource-type/static-resource-type.seed.ts
+++ b/src/services/static-resource-type/static-resource-type.seed.ts
@@ -1,7 +1,7 @@
 export const seed = {
   disabled: (process.env.FORCE_DB_REFRESH !== 'true'),
   delete: (process.env.FORCE_DB_REFRESH === 'true'),
-  path: 'static-resource-staticResourceType',
+  path: 'static-resource-type',
   randomize: false,
   templates: [
     { type: 'image' },


### PR DESCRIPTION
Added support for stereoscopic videos. Passing in metadata.stereoscopic: true will make ffmpeg crop out the right eye and rotate + stretch the left eye to match how mono videos look.

Fixed omission of parentResourceId on videos' thumbnails.

Thumbnail will be grabbed from source if metadata.thumbnail_url is null or a string of 0 length.

Fixed some bugs in mapping of urls to correct db entry caused by shared references to context.

Changed staticResource.type references to staticResource.staticResourceType.

Made staticResource.description field 1024 characters long instead of default 256.

Fixed staticResourceType seeder path to point to correct table.