### PR TITLE
Quick video pagination workaround

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -6,7 +6,7 @@
   "public": "../public/",
   "paginate": {
     "default": 10,
-    "max": 50
+    "max": 100
   },
   "authentication": {
     "entity": "identity-provider",


### PR DESCRIPTION
Increasing the maximum pagination limit from 50 to 100 since client currently doesn't have proper pagination and this is a quick fix to get all of Kai's videos at once.

What is the purpose of this PR? 
A quick workaround to get all 100 of Kai's videos in the Explore page

What does issue #s are solved by this PR?
No specific issue

What unit tests have been put in place?
None

How does our QA team test this PR?
Go to Explore page with ~100 videos in the database and make sure they are all in the grid.

What files or features are including in this PR that are not related to the main feature?
None