### PR TITLE
Admin videos

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "bcrypt": "^4.0.1",
     "bent": "^7.3.0",
     "camelcase": "^6.0.0",
+    "cli": "^1.0.1",
     "compression": "^1.7.4",
     "config": "^3.3.1",
     "cors": "^2.8.5",

--- a/scripts/make-user-admin.js
+++ b/scripts/make-user-admin.js
@@ -1,5 +1,4 @@
 const dotenv = require('dotenv')
-
 const cli = require('cli')
 const Sequelize = require('sequelize')
 
@@ -9,52 +8,52 @@ import { db } from '../src/db-config'
 cli.enable('status')
 
 cli.parse({
-	userId: [false, 'UserID to make admin', 'string']
+  userId: [false, 'UserID to make admin', 'string']
 });
 
 cli.main(async function(args, options) {
-	try {
-		const sequelizeClient = new Sequelize({
-			...db,
-			logging: true,
-			define: {
-				freezeTableName: true
-			}
-		})
+  try {
+    const sequelizeClient = new Sequelize({
+      ...db,
+      logging: true,
+      define: {
+        freezeTableName: true
+      }
+    })
 
-		await sequelizeClient.sync()
+    await sequelizeClient.sync()
 
-		const User = sequelizeClient.define('user', {
-			id: {
-				type: Sequelize.DataTypes.UUID,
-				defaultValue: Sequelize.DataTypes.UUIDV1,
-				allowNull: false,
-				primaryKey: true
-			},
-			name: {
-				type: Sequelize.DataTypes.STRING,
-				allowNull: false
-			},
-			userRole: {
-				type: Sequelize.DataTypes.STRING,
-				allowNull: true
-			}
-		});
+    const User = sequelizeClient.define('user', {
+      id: {
+        type: Sequelize.DataTypes.UUID,
+        defaultValue: Sequelize.DataTypes.UUIDV1,
+        allowNull: false,
+        primaryKey: true
+      },
+      name: {
+        type: Sequelize.DataTypes.STRING,
+        allowNull: false
+      },
+      userRole: {
+        type: Sequelize.DataTypes.STRING,
+        allowNull: true
+      }
+    });
 
-		console.log(options.userId)
-		const userMatch = await User.findOne({
-			where: {
-				id: options.userId
-			}
-		})
+    console.log(options.userId)
+    const userMatch = await User.findOne({
+      where: {
+        id: options.userId
+      }
+    })
 
-		userMatch.userRole = 'admin'
-		await userMatch.save()
+    userMatch.userRole = 'admin'
+    await userMatch.save()
 
-		this.ok('User with ID ' + options.userId + ' made an admin')
-		process.exit(0);
-	}
-	catch(err) {
-		this.fatal(err)
-	}
+    this.ok('User with ID ' + options.userId + ' made an admin')
+    process.exit(0);
+  }
+  catch(err) {
+    this.fatal(err)
+  }
 })

--- a/scripts/make-user-admin.js
+++ b/scripts/make-user-admin.js
@@ -1,0 +1,72 @@
+const dotenv = require('dotenv')
+
+const cli = require('cli')
+const Sequelize = require('sequelize')
+
+dotenv.config()
+
+const db = {
+	username: process.env.MYSQL_USER || 'server',
+	password: process.env.MYSQL_PASSWORD || 'password',
+	database: process.env.MYSQL_DATABASE || 'xrchat',
+	host: process.env.MYSQL_HOST || 'localhost',
+	port: process.env.MYSQL_PORT || 3306,
+	dialect: 'mysql',
+	forceRefresh: process.env.FORCE_DB_REFRESH === 'true'
+}
+
+db.url = process.env.MYSQL_URL || `mysql://${db.username}:${db.password}@${db.host}:${db.port}/${db.database}`
+
+
+cli.enable('status')
+
+cli.parse({
+	userId: [false, 'UserID to make admin', 'string']
+});
+
+cli.main(async function(args, options) {
+	try {
+		const sequelizeClient = new Sequelize({
+			...db,
+			logging: true,
+			define: {
+				freezeTableName: true
+			}
+		})
+
+		await sequelizeClient.sync()
+
+		const User = sequelizeClient.define('user', {
+			id: {
+				type: Sequelize.DataTypes.UUID,
+				defaultValue: Sequelize.DataTypes.UUIDV1,
+				allowNull: false,
+				primaryKey: true
+			},
+			name: {
+				type: Sequelize.DataTypes.STRING,
+				allowNull: false
+			},
+			userRole: {
+				type: Sequelize.DataTypes.STRING,
+				allowNull: true
+			}
+		});
+
+		console.log(options.userId)
+		const userMatch = await User.findOne({
+			where: {
+				id: options.userId
+			}
+		})
+
+		userMatch.userRole = 'admin'
+		await userMatch.save()
+
+		this.ok('User with ID ' + options.userId + ' made an admin')
+		process.exit(0);
+	}
+	catch(err) {
+		this.fatal(err)
+	}
+})

--- a/scripts/make-user-admin.js
+++ b/scripts/make-user-admin.js
@@ -4,19 +4,7 @@ const cli = require('cli')
 const Sequelize = require('sequelize')
 
 dotenv.config()
-
-const db = {
-	username: process.env.MYSQL_USER || 'server',
-	password: process.env.MYSQL_PASSWORD || 'password',
-	database: process.env.MYSQL_DATABASE || 'xrchat',
-	host: process.env.MYSQL_HOST || 'localhost',
-	port: process.env.MYSQL_PORT || 3306,
-	dialect: 'mysql',
-	forceRefresh: process.env.FORCE_DB_REFRESH === 'true'
-}
-
-db.url = process.env.MYSQL_URL || `mysql://${db.username}:${db.password}@${db.host}:${db.port}/${db.database}`
-
+import { db } from '../src/db-config'
 
 cli.enable('status')
 

--- a/src/hooks/add-upload-path.ts
+++ b/src/hooks/add-upload-path.ts
@@ -4,7 +4,7 @@ import getBasicMimetype from '../util/get-basic-mimetype'
 
 export default function (options = {}): Hook {
   return async (context: HookContext) => {
-    context.params.uploadPath = context.params.uploadPath ? context.params.uploadPath : path.join(context.params.uuid, getBasicMimetype(context.params.mime_type))
+    context.params.uploadPath = context.params.uploadPath ? context.params.uploadPath : path.join(context.params.uuid, getBasicMimetype(context.params.mimeType))
     return context
   }
 }

--- a/src/hooks/convert-video.ts
+++ b/src/hooks/convert-video.ts
@@ -79,10 +79,11 @@ export default async (context: any): Promise<void> => {
     let thumbnailUploadResult: any
     const localContext = _.cloneDeep(context)
 
+    localContext.data.subscriptionLevel = localContext.data.subscriptionLevel ? localContext.data.subscriptionLevel : 'all'
     localContext.params.storageProvider = new StorageProvider()
     localContext.params.uploadPath = path.join('public', localContext.params.videoSource, fileId, 'video')
 
-    if (context.data.metadata.thumbnail_url != null && context.data.metadata.thumbnail_url.length > 0) {
+    if (localContext.data.metadata.thumbnail_url != null && localContext.data.metadata.thumbnail_url.length > 0) {
       thumbnailUploadResult = await uploadThumbnailLinkHook()(localContext)
       localContext.params.thumbnailUrl = localContext.data.metadata.thumbnail_url = thumbnailUploadResult.params.thumbnailUrl
     }
@@ -247,9 +248,9 @@ export default async (context: any): Promise<void> => {
           const mimetype = mimetypeDict[extension]
 
           localContext.data.url = s3.endpoint.href + path.join(s3BlobStore.bucket, key)
-          localContext.data.mime_type = mimetype
+          localContext.data.mimeType = mimetype
 
-          localContext.params.mime_type = mimetype
+          localContext.params.mimeType = mimetype
           localContext.params.uploadPath = s3Path
 
           if (extension === 'mpd') {
@@ -314,10 +315,10 @@ const uploadFile = async (localFilePath: string, fileId: string, context: any, a
             localContext.params.body = {
               name: file,
               metadata: localContext.data.metadata,
-              mime_type: mimetype
+              mimeType: mimetype
             }
 
-            localContext.params.mime_type = mimetype
+            localContext.params.mimeType = mimetype
             localContext.params.storageProvider = new StorageProvider()
             localContext.params.uploadPath = path.join('public', localContext.params.videoSource, fileId, 'video')
 

--- a/src/hooks/convert-video.ts
+++ b/src/hooks/convert-video.ts
@@ -281,6 +281,8 @@ export default async (context: any): Promise<void> => {
   } else {
     console.log('Regex for ' + url + ' did not match anything known')
 
+    await app.service('static-resource').remove(result.id)
+
     return context
   }
 }

--- a/src/hooks/create-static-resource.ts
+++ b/src/hooks/create-static-resource.ts
@@ -10,17 +10,21 @@ export default (options = {}): Hook => {
       name: data.name || body.name || context.params.file.originalname,
       description: data.description || body.description,
       url: data.uri || data.url,
-      mime_type: data.mime_type || params.mime_type,
+      mimeType: data.mimeType || params.mimeType,
       metadata: data.metadata || body.metadata,
-      staticResourceType: 'data'
+      staticResourceType: 'data',
+      subscriptionLevel: data.subscriptionLevel || body.subscriptionLevel || params.subscriptionLevel || 'all',
+      userId: data.userId || body.userId || params.userId || null
     }
     resourceData.staticResourceType = data.type === 'user-thumbnail' || body.type === 'user-thumbnail'
       ? 'user-thumbnail'
-      : getBasicMimetype(resourceData.mime_type)
+      : getBasicMimetype(resourceData.mimeType)
     if (context.params.skipResourceCreation === true) {
       context.result = await context.app.service('static-resource').patch(context.params.patchId, {
         url: resourceData.url,
-        metadata: resourceData.metadata
+        metadata: resourceData.metadata,
+        staticResourceType: resourceData.staticResourceType,
+        subscriptionLevel: resourceData.subscriptionLevel
       })
     } else {
       if (context.params.parentResourceId) {

--- a/src/hooks/reformat-upload-result.ts
+++ b/src/hooks/reformat-upload-result.ts
@@ -10,7 +10,7 @@ export default (options = {}): Hook => {
 
     const storage = context.params.storageProvider.getStorage()
 
-    const url = 'https://s3.amazonaws.com/' + (storage.bucket as string) + '/' + (context.result.id as string)
+    const url = 'https://s3.amazonaws.com/' + (storage.bucket as string) + '/' + (context.result.id as string || context.data.id as string)
 
     context.data.url = url
 

--- a/src/hooks/remove-related-resources.ts
+++ b/src/hooks/remove-related-resources.ts
@@ -21,21 +21,25 @@ export default (options = {}): Hook => {
       const staticResource = staticResourceResult.data[0]
 
       const storageRemovePromise = new Promise((resolve, reject) => {
-        const key = staticResource.url.replace('https://s3.amazonaws.com/' + (config.get('aws.s3.static_resource_bucket') as string) + '/', '')
+        if (staticResource.url && staticResource.url.length > 0) {
+          const key = staticResource.url.replace('https://s3.amazonaws.com/' + (config.get('aws.s3.static_resource_bucket') as string) + '/', '')
 
-        if (storage === undefined) reject(new Error('Storage is undefined'))
+          if (storage === undefined) reject(new Error('Storage is undefined'))
 
-        storage.remove({
-          key: key
-        }, (err: any, result: any) => {
-          if (err) {
-            console.log('Storage removal error')
-            console.log(err)
-            reject(err)
-          }
+          storage.remove({
+            key: key
+          }, (err: any, result: any) => {
+            if (err) {
+              console.log('Storage removal error')
+              console.log(err)
+              reject(err)
+            }
 
-          resolve(result)
-        })
+            resolve(result)
+          })
+        } else {
+          resolve()
+        }
       })
 
       const children = await getAllChildren(staticResourceService, id, 0)
@@ -48,6 +52,7 @@ export default (options = {}): Hook => {
           } catch (err) {
             console.log('Failed to remove child: ')
             console.log(child.id)
+            console.log(err)
             reject(err)
           }
 

--- a/src/hooks/replace-thumbnail-link.ts
+++ b/src/hooks/replace-thumbnail-link.ts
@@ -1,0 +1,38 @@
+import config from 'config'
+import { Hook, HookContext } from '@feathersjs/feathers'
+import uploadThumbnailLinkHook from './upload-thumbnail-link'
+import StorageProvider from '../storage/storageprovider'
+import _ from 'lodash'
+
+export default (options = {}): Hook => {
+  return async (context: HookContext) => {
+    const { app, data, params } = context
+    if (data.id) {
+      const currentResource = await app.service('static-resource').get(data.id)
+      currentResource.metadata = JSON.parse(currentResource.metadata)
+
+      if (currentResource.metadata.thumbnail_url !== data.metadata.thumbnail_url && data.metadata.thumbnail_url != null && data.metadata.thumbnail_url.length > 0) {
+        const existingThumbnails = await app.service('static-resource').find({
+          query: {
+            userId: params['identity-provider'].userId,
+            parentResourceId: data.id,
+            url: currentResource.metadata.thumbnail_url || ''
+          }
+        })
+
+        await Promise.all(existingThumbnails.data.map(async (item: any) => {
+          return app.service('static-resource').remove(item.id)
+        }))
+        params.parentResourceId = data.id
+        params.uploadPath = data.url.replace('https://s3.amazonaws.com/' + (config.get('aws.s3.static_resource_bucket') as string) + '/', '')
+        params.uploadPath = params.uploadPath.replace('/manifest.mpd', '')
+        params.storageProvider = new StorageProvider()
+        const contextClone = _.cloneDeep(context)
+        const result = await uploadThumbnailLinkHook()(contextClone)
+        data.metadata.thumbnail_url = (result as any).params.thumbnailUrl
+      }
+    }
+
+    return context
+  }
+}

--- a/src/hooks/restrict-user-role.ts
+++ b/src/hooks/restrict-user-role.ts
@@ -5,17 +5,13 @@ import config from 'config'
 const loggedInUserEntity: string = config.get('authentication.entity') || 'user'
 
 // This will attach the owner ID in the contact while creating/updating list item
-export default (propertyName: string) => {
-  return (context: HookContext): HookContext => {
+export default (userRole: string) => {
+  return async (context: HookContext) => {
     // Getting logged in user and attaching owner of user
     const loggedInUser = context.params[loggedInUserEntity]
-    context.params.body = {
-      ...context.params.body,
-      [propertyName]: loggedInUser.userId
-    }
-    context.data = {
-      ...context.data,
-      [propertyName]: loggedInUser.userId
+    const user = await context.app.service('user').get(loggedInUser.userId)
+    if (user.userRole !== userRole) {
+      throw new Error('Must be admin to access this function')
     }
 
     return context

--- a/src/hooks/upload-thumbnail-link.ts
+++ b/src/hooks/upload-thumbnail-link.ts
@@ -6,13 +6,15 @@ const getBuffer = bent('buffer')
 
 export default (options = {}): Hook => {
   return async (context: HookContext) => {
-    const { app, result } = context
-    const extensionMatch = result.metadata.thumbnail_url.match(fileRegex)
-    if (result.id != null && result.metadata.thumbnail_url && extensionMatch != null) {
+    const { app, result, data, params } = context
+    const metadata = result?.metadata || data?.metadata
+    const id = result?.id || data?.id
+    const extensionMatch = metadata.thumbnail_url.match(fileRegex)
+    if (id != null && metadata.thumbnail_url && extensionMatch != null) {
       const extension = extensionMatch[1] as string
-      const url = result.metadata.thumbnail_url
+      const url = metadata.thumbnail_url
       const fileBuffer = await getBuffer(url)
-      context.params.file = {
+      params.file = {
         fieldname: 'file',
         originalname: 'thumbnail.' + extension,
         encoding: '7bit',
@@ -20,21 +22,21 @@ export default (options = {}): Hook => {
         size: fileBuffer.byteLength
       }
 
-      context.params.mimeType = context.params.file.mimetype = 'image/' + extension
-      context.params.subscriptionLevel = context.data.subscriptionLevel
-      context.data.name = context.params.file.originalname
+      params.mimeType = params.file.mimetype = 'image/' + extension
+      params.subscriptionLevel = context.data.subscriptionLevel
+      context.data.name = params.file.originalname
       context.data.metadata = context.data.metadata ? context.data.metadata : {}
-      context.data.parentResourceId = context.params.parentResourceId
-      context.params.uploadPath = context.params.uploadPath.replace('video', 'image')
-      const uploadResult = await app.services.upload.create(context.data, context.params)
-      const parent = await app.services['static-resource'].get(result.id)
-      const metadata = JSON.parse(parent.metadata)
-      metadata.thumbnail_url = uploadResult.url
-      await app.services['static-resource'].patch(result.id, {
-        metadata: metadata
+      context.data.parentResourceId = params.parentResourceId
+      params.uploadPath = params.uploadPath.replace('video', 'image')
+      const uploadResult = await app.services.upload.create(context.data, params)
+      const parent = await app.services['static-resource'].get(id)
+      const parsedMetadata = JSON.parse(parent.metadata)
+      parsedMetadata.thumbnail_url = uploadResult.url
+      await app.services['static-resource'].patch(id, {
+        metadata: parsedMetadata
       })
 
-      context.params.thumbnailUrl = metadata.thumbnail_url
+      params.thumbnailUrl = parsedMetadata.thumbnail_url
 
       return context
     } else {

--- a/src/hooks/upload-thumbnail-link.ts
+++ b/src/hooks/upload-thumbnail-link.ts
@@ -20,7 +20,8 @@ export default (options = {}): Hook => {
         size: fileBuffer.byteLength
       }
 
-      context.params.mime_type = context.params.file.mimetype = 'image/' + extension
+      context.params.mimeType = context.params.file.mimetype = 'image/' + extension
+      context.params.subscriptionLevel = context.data.subscriptionLevel
       context.data.name = context.params.file.originalname
       context.data.metadata = context.data.metadata ? context.data.metadata : {}
       context.data.parentResourceId = context.params.parentResourceId

--- a/src/hooks/upload-thumbnail.ts
+++ b/src/hooks/upload-thumbnail.ts
@@ -5,7 +5,7 @@ export default (options = {}): Hook => {
     const { app } = context
     if (context.params.thumbnail) {
       context.params.file = context.params.thumbnail
-      context.params.mime_type = context.params.file.mimetype
+      context.params.mimeType = context.params.file.mimetype
       context.params.parentResourceId = context.result.id
       context.data.metadata = context.data.metadata ? context.data.metadata : {}
       delete context.params.thumbnail

--- a/src/models/static-resource.model.ts
+++ b/src/models/static-resource.model.ts
@@ -22,7 +22,7 @@ export default (app: Application): any => {
       type: DataTypes.STRING,
       allowNull: false
     },
-    mime_type: {
+    mimeType: {
       type: DataTypes.STRING,
       allowNull: false
     },
@@ -43,7 +43,8 @@ export default (app: Application): any => {
     (staticResource as any).belongsTo(models.attribution);
     (staticResource as any).belongsToMany(models.component, { through: 'static_resource_component' });
     (staticResource as any).belongsTo(models.user);
-    (staticResource as any).hasMany(models.static_resource, { as: 'parent', foreignKey: 'parentResourceId', allowNull: true })
+    (staticResource as any).hasMany(models.static_resource, { as: 'parent', foreignKey: 'parentResourceId', allowNull: true });
+    (staticResource as any).belongsTo(models.subscription_level, { foreignKey: 'subscriptionLevel' })
   }
 
   return staticResource

--- a/src/models/subscription-level.model.ts
+++ b/src/models/subscription-level.model.ts
@@ -1,0 +1,30 @@
+import { Sequelize, DataTypes } from 'sequelize'
+import { Application } from '../declarations'
+
+export default (app: Application): any => {
+  const sequelizeClient: Sequelize = app.get('sequelizeClient')
+  const subscriptionLevel = sequelizeClient.define('subscription_level', {
+    level: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      primaryKey: true,
+      unique: true
+    }
+  }, {
+    hooks: {
+      beforeCount (options: any) {
+        options.raw = true
+      },
+      beforeUpdate (instance: any, options: any) {
+        throw new Error("Can't update a type!")
+      }
+    },
+    timestamps: false
+  });
+
+  (subscriptionLevel as any).associate = (models: any) => {
+    (subscriptionLevel as any).hasMany(models.static_resource, { foreignKey: 'subscriptionLevel' })
+  }
+
+  return subscriptionLevel
+}

--- a/src/seeder-config.ts
+++ b/src/seeder-config.ts
@@ -7,6 +7,7 @@ import GroupUserRankSeed from './services/group-user-rank/group-user-rank.seed'
 import IdentityProviderTypeSeed from './services/identity-provider-type/identity-provider-type.seed'
 import ResourceTypeSeed from './services/resource-type/resource-type.seed'
 import StaticResourceTypeSeed from './services/static-resource-type/static-resource-type.seed'
+import SubscriptionLevelSeed from './services/subscription-level/subscription-level.seed'
 import SubscriptionTypeSeed from './services/subscription-type/subscription-type.seed'
 import UserRelationshipTypeSeed from './services/user-relationship-type/user-relationship-type.seed'
 import UserRoleSeed from './services/user-role/user-role.seed'
@@ -22,6 +23,7 @@ module.exports = {
     IdentityProviderTypeSeed,
     ResourceTypeSeed,
     StaticResourceTypeSeed,
+    SubscriptionLevelSeed,
     SubscriptionTypeSeed,
     UserRelationshipTypeSeed,
     UserRoleSeed

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -9,6 +9,7 @@ import GroupUserRank from './group-user-rank/group-user-rank.service'
 import IdentityProviderType from './identity-provider-type/identity-provider-type.service'
 import ResourceType from './resource-type/resource-type.service'
 import StaticResourceType from './static-resource-type/static-resource-type.service'
+import SubscriptionLevel from './subscription-level/subscription-level.service'
 import UserRelationshipType from './user-relationship-type/user-relationship-type.service'
 import UserRole from './user-role/user-role.service'
 import SubscriptionType from './subscription-type/subscription-type.service'
@@ -77,6 +78,7 @@ export default (app: Application): void => {
   app.configure(SubscriptionType)
   app.configure(AccessControlScope)
   app.configure(GroupUserRank)
+  app.configure(SubscriptionLevel)
 
   // Objects
   app.configure(AccessControl)

--- a/src/services/resource-type/resource-type.seed.ts
+++ b/src/services/resource-type/resource-type.seed.ts
@@ -27,6 +27,7 @@ export const seed = {
       { type: 'userRole' },
       { type: 'staticResource' },
       { type: 'staticResourceType' },
+      { type: 'subscriptionType' },
       { type: 'user' }
     ]
 }

--- a/src/services/static-resource/static-resource.hooks.ts
+++ b/src/services/static-resource/static-resource.hooks.ts
@@ -23,7 +23,7 @@ export default {
         if (!context.data.uri && context.params.file) {
           const file = context.params.file
           const uri = dauria.getBase64DataURI(file.buffer, file.mimetype)
-          const mimeType = context.data.mime_type ?? file.mimetype
+          const mimeType = context.data.mimeType ?? file.mimetype
           const name = context.data.name ?? file.name
           context.data = { uri: uri, mimeType: mimeType, name: name }
         }

--- a/src/services/static-resource/static-resource.hooks.ts
+++ b/src/services/static-resource/static-resource.hooks.ts
@@ -1,8 +1,13 @@
 import { HookContext } from '@feathersjs/feathers'
+import { hooks } from '@feathersjs/authentication'
 import dauria from 'dauria'
 import removeRelatedResources from '../../hooks/remove-related-resources'
 import collectAnalytics from '../../hooks/collect-analytics'
 import addAssociations from '../../hooks/add-associations'
+import replaceThumbnailLink from '../../hooks/replace-thumbnail-link'
+
+const { authenticate } = hooks
+
 export default {
   before: {
     all: [],
@@ -19,6 +24,7 @@ export default {
     ],
     get: [],
     create: [
+      authenticate('jwt'),
       (context: HookContext) => {
         if (!context.data.uri && context.params.file) {
           const file = context.params.file
@@ -30,9 +36,15 @@ export default {
         return context
       }
     ],
-    update: [],
-    patch: [],
-    remove: [removeRelatedResources()]
+    update: [authenticate('jwt')],
+    patch: [
+      authenticate('jwt'),
+      replaceThumbnailLink()
+    ],
+    remove: [
+      authenticate('jwt'),
+      removeRelatedResources()
+    ]
   },
 
   after: {

--- a/src/services/subscription-level/subscription-level.class.ts
+++ b/src/services/subscription-level/subscription-level.class.ts
@@ -1,0 +1,8 @@
+import { Service, SequelizeServiceOptions } from 'feathers-sequelize'
+import { Application } from '../../declarations'
+
+export class SubscriptionLevel extends Service {
+  constructor (options: Partial<SequelizeServiceOptions>, app: Application) {
+    super(options)
+  }
+}

--- a/src/services/subscription-level/subscription-level.hooks.ts
+++ b/src/services/subscription-level/subscription-level.hooks.ts
@@ -1,0 +1,33 @@
+import { disallow } from 'feathers-hooks-common'
+
+export default {
+  before: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [disallow()],
+    patch: [disallow()],
+    remove: []
+  },
+
+  after: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  },
+
+  error: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  }
+}

--- a/src/services/subscription-level/subscription-level.seed.ts
+++ b/src/services/subscription-level/subscription-level.seed.ts
@@ -1,15 +1,12 @@
 export const seed = {
   disabled: (process.env.FORCE_DB_REFRESH !== 'true'),
   delete: (process.env.FORCE_DB_REFRESH === 'true'),
+  path: 'subscription-level',
   randomize: false,
-  path: 'user-role',
-  templates:
-    [
-      { role: 'admin' },
-      { role: 'moderator' },
-      { role: 'user' },
-      { role: 'guest' }
-    ]
+  templates: [
+    { level: 'all' },
+    { level: 'paid' }
+  ]
 }
 
 export default seed

--- a/src/services/subscription-level/subscription-level.service.ts
+++ b/src/services/subscription-level/subscription-level.service.ts
@@ -1,0 +1,25 @@
+import { ServiceAddons } from '@feathersjs/feathers'
+import { Application } from '../../declarations'
+import { SubscriptionLevel } from './subscription-level.class'
+import createModel from '../../models/subscription-level.model'
+import hooks from './subscription-level.hooks'
+
+declare module '../../declarations' {
+  interface ServiceTypes {
+    'subscription-level': SubscriptionLevel & ServiceAddons<any>
+  }
+}
+
+export default (app: Application): any => {
+  const options = {
+    Model: createModel(app),
+    paginate: app.get('paginate'),
+    multi: true
+  }
+
+  app.use('/subscription-level', new SubscriptionLevel(options, app))
+
+  const service = app.service('subscription-level')
+
+  service.hooks(hooks)
+}

--- a/src/services/upload-media/upload-media.hooks.ts
+++ b/src/services/upload-media/upload-media.hooks.ts
@@ -22,7 +22,7 @@ const createOwnedFile = (options = {}) => {
       owned_file_id: body.fileId,
       name: data.name || body.name,
       key: data.uri || data.url,
-      content_type: data.mime_type || params.mime_type,
+      content_type: data.mimeType || params.mimeType,
       metadata: data.metadata || body.metadata,
       state: 'active',
       content_length: params.file.size

--- a/src/services/upload-media/upload-media.service.ts
+++ b/src/services/upload-media/upload-media.service.ts
@@ -26,7 +26,7 @@ export default (app: Application): void => {
         console.log('req.feathers.file ', req.feathers.file)
         req.feathers.body = (req as any).body
         req.feathers.body.fileId = uuidv1()
-        req.feathers.mime_type = req.feathers.file.mimetype
+        req.feathers.mimeType = req.feathers.file.mimetype
         req.feathers.storageProvider = provider
         req.feathers.thumbnail = (req as any).files.thumbnail ? (req as any).files.thumbnail[0] : null
         req.feathers.uploadPath = req.feathers.body.fileId

--- a/src/services/upload/upload.class.ts
+++ b/src/services/upload/upload.class.ts
@@ -33,7 +33,7 @@ export class Upload implements ServiceMethods<Data> {
       name: (data as any).name,
       description: (data as any).description,
       url: (data as any).url,
-      mime_type: (data as any).mime_type
+      mimeType: (data as any).mimeType
     })
 
     return result

--- a/src/services/upload/upload.service.ts
+++ b/src/services/upload/upload.service.ts
@@ -25,7 +25,7 @@ export default (app: Application): void => {
       if (req?.feathers) {
         req.feathers.file = (req as any).files.file ? (req as any).files.file[0] : null
         req.feathers.body = (req as any).body
-        req.feathers.mime_type = req.feathers.file.mimetype
+        req.feathers.mimeType = req.feathers.file.mimetype
         req.feathers.storageProvider = provider
         req.feathers.thumbnail = (req as any).files.thumbnail ? (req as any).files.thumbnail[0] : null
         next()

--- a/src/services/video/video.class.ts
+++ b/src/services/video/video.class.ts
@@ -30,8 +30,8 @@ export class Video implements ServiceMethods<Data> {
       return await Promise.all(data.map(current => this.create(current, params)))
     }
 
-    (data as any).mime_type = 'application/dash+xml';
-    (data as any).type = getBasicMimetype((data as any).mime_type)
+    (data as any).mimeType = 'application/dash+xml';
+    (data as any).type = getBasicMimetype((data as any).mimeType)
 
     const result = await this.app.service('static-resource').create(data)
 

--- a/src/services/video/video.hooks.ts
+++ b/src/services/video/video.hooks.ts
@@ -1,18 +1,25 @@
-// import * as authentication from '@feathersjs/authentication'
+import { hooks } from '@feathersjs/authentication'
+import { disallow } from 'feathers-hooks-common'
 import convertVideo from '../../hooks/convert-video'
 import addAttribution from '../../hooks/add-attribution'
-// import createResource from '../../hooks/create-resource'
+import restrictUserRole from '../../hooks/restrict-user-role'
+import addUserToBody from '../../hooks/set-loggedin-user-in-body'
 // Don't remove this comment. It's needed to format import lines nicely.
+
+const { authenticate } = hooks
 
 export default {
   before: {
-    all: [],
-    find: [],
-    get: [],
-    create: [],
-    update: [],
-    patch: [],
-    remove: []
+    all: [
+      authenticate('jwt'),
+      restrictUserRole('admin')
+    ],
+    find: [disallow()],
+    get: [disallow()],
+    create: [addUserToBody('userId')],
+    update: [disallow()],
+    patch: [disallow()],
+    remove: [disallow()]
   },
 
   after: {

--- a/test/models/static-resource.test.ts
+++ b/test/models/static-resource.test.ts
@@ -8,7 +8,7 @@ describe('CRUD operation on \'Static Resource\' model', () => {
       name: 'test',
       description: 'description',
       url: 'http://localhost:3030',
-      mime_type: 'image/png',
+      mimeType: 'image/png',
       metadata: JSON.stringify({ data: 'test' })
     }).then(res => {
       done()


### PR DESCRIPTION
**What is the purpose of this PR?**
Updating the backend to work with the admin console on the client.
Preparing content to be gated behind one or more paid tiers.
Better implement staticResource patching so that changing the thumbnail_url on
a video will cache the new thumbnail and remove the old one.

**What does issue #s are solved by this PR?**
No specific issues

**What unit tests have been put in place?**
None

**What files or features are including in this PR that are not related to the main feature?**
New script script/make-user-admin.js
Updated field 'staticResource.mime_type' to 'staticResource.mimeType'.
Added table subscriptionLevel and added it as a field to staticResource.

**How does our QA team test this PR?**
This is most easily tested in conjunction with the branch 'admin-video' of client:

Sign up as a user in the client.
Find out what the user's ID is. If testing locally, you can run `mysql -h 127.0.0.1 -u server -p` and enter the local password; then do `use xrchat`, then `select * from user` and note the ID.
From the top level of the package, run `node scripts/make-user-admin.js --userId=<user_id>`. It should return OK and, if you inspect the user in the SQL database, its userRole field should be 'admin'.

Back in the client, refresh the page and open the Nav menu in the upper right. There should be a new option 'Admin Console'. Click on that to be taken to the admin console.
From here, you can make new videos, edit existing ones (other than the URL of the video, didn't feel like making patching handle that), and delete existing ones.
You can make a video, patch its thumbnail_url and refresh the page after a few seconds to see that it's changed. Deleting a video should remove it from the admin console after a refresh (didn't implement subscriptions to listen for that), and if you check out the static_resource table after it's removed there should be nothing remaining (assuming you deleted all of the videos locally).

Note that, as videos are still all being uploaded to S3 into a shared public folder, if you delete a video, all other references to it on other people's local setups, as well as on dev, staging, and beta, will be broken. You can upload it again to put it back and fix all those references. Once the media server setup is in place, I will probably get rid of the shared public sourcing so that we don't have this issue.