### PR TITLE
Seats

### DIFF
--- a/src/email-templates/account/magiclink-email-subscription.pug
+++ b/src/email-templates/account/magiclink-email-subscription.pug
@@ -1,0 +1,11 @@
+doctype html
+html
+  body(style='margin: 0;font-family: Tahoma;font-size: 1.2em;background-color: #ECF0F1;')
+    header.text-center(style='padding: 1em;background-color: #34495E;margin-bottom: 1em;text-align: center;')
+      .logo(style='max-width: 33.33%;')
+        img(src=logo)
+    .body(style='padding: 1em;margin-right: auto;margin-left: auto;max-width: 500px;color: #2C3E50;')
+      h1(style='font-family: Palatino;font-size: 1.5em;') Hello
+      p You have been invited to join KaiXR by #{subscriptionName}
+      p Please click the below link to sign in.
+      a.reset-btn(href=hashLink, style='color: #2980B9;') #{hashLink}

--- a/src/email-templates/account/magiclink-email-subscription.pug
+++ b/src/email-templates/account/magiclink-email-subscription.pug
@@ -6,6 +6,6 @@ html
         img(src=logo)
     .body(style='padding: 1em;margin-right: auto;margin-left: auto;max-width: 500px;color: #2C3E50;')
       h1(style='font-family: Palatino;font-size: 1.5em;') Hello
-      p You have been invited to join KaiXR by #{subscriptionName}
+      p You have been invited to join KaiXR by #{username}
       p Please click the below link to sign in.
       a.reset-btn(href=hashLink, style='color: #2980B9;') #{hashLink}

--- a/src/models/seat-status.model.ts
+++ b/src/models/seat-status.model.ts
@@ -1,10 +1,10 @@
 // See http://docs.sequelizejs.com/en/latest/docs/models-definition/
 // for more of what you can do here.
-import { Sequelize, DataTypes } from 'sequelize';
-import { Application } from '../declarations';
+import { Sequelize, DataTypes } from 'sequelize'
+import { Application } from '../declarations'
 
-export default function (app: Application) {
-  const sequelizeClient: Sequelize = app.get('sequelizeClient');
+export default function (app: Application): any {
+  const sequelizeClient: Sequelize = app.get('sequelizeClient')
   const seatStatus = sequelizeClient.define('seat_status', {
     status: {
       type: DataTypes.STRING,
@@ -14,8 +14,8 @@ export default function (app: Application) {
     }
   }, {
     hooks: {
-      beforeCount(options: any) {
-        options.raw = true;
+      beforeCount (options: any) {
+        options.raw = true
       }
     },
     timestamps: false
@@ -26,7 +26,7 @@ export default function (app: Application) {
     // Define associations here
     // See http://docs.sequelizejs.com/en/latest/docs/associations/
     (seatStatus as any).hasMany(models.seat, { foreignKey: 'seatStatus' })
-  };
+  }
 
-  return seatStatus;
+  return seatStatus
 }

--- a/src/models/seat-status.model.ts
+++ b/src/models/seat-status.model.ts
@@ -1,0 +1,32 @@
+// See http://docs.sequelizejs.com/en/latest/docs/models-definition/
+// for more of what you can do here.
+import { Sequelize, DataTypes } from 'sequelize';
+import { Application } from '../declarations';
+
+export default function (app: Application) {
+  const sequelizeClient: Sequelize = app.get('sequelizeClient');
+  const seatStatus = sequelizeClient.define('seat_status', {
+    status: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      primaryKey: true,
+      unique: true
+    }
+  }, {
+    hooks: {
+      beforeCount(options: any) {
+        options.raw = true;
+      }
+    },
+    timestamps: false
+  });
+
+  // eslint-disable-next-line no-unused-vars
+  (seatStatus as any).associate = function (models: any) {
+    // Define associations here
+    // See http://docs.sequelizejs.com/en/latest/docs/associations/
+    (seatStatus as any).hasMany(models.seat, { foreignKey: 'seatStatus' })
+  };
+
+  return seatStatus;
+}

--- a/src/models/seat.model.ts
+++ b/src/models/seat.model.ts
@@ -1,16 +1,16 @@
 // See http://docs.sequelizejs.com/en/latest/docs/models-definition/
 // for more of what you can do here.
-import { Sequelize, DataTypes } from 'sequelize';
-import { Application } from '../declarations';
+import { Sequelize } from 'sequelize'
+import { Application } from '../declarations'
 
-export default function (app: Application) {
-  const sequelizeClient: Sequelize = app.get('sequelizeClient');
+export default function (app: Application): any {
+  const sequelizeClient: Sequelize = app.get('sequelizeClient')
   const seat = sequelizeClient.define('seat', {
-    
+
   }, {
     hooks: {
-      beforeCount(options: any) {
-        options.raw = true;
+      beforeCount (options: any) {
+        options.raw = true
       }
     }
   });
@@ -20,9 +20,9 @@ export default function (app: Application) {
     // Define associations here
     // See http://docs.sequelizejs.com/en/latest/docs/associations/
     (seat as any).belongsTo(models.subscription, { foreignKey: { name: 'subscriptionId', allowNull: false } })
-    ;(seat as any).belongsTo(models.user, { foreignKey: { name: 'userId', allowNull: false }})
-    ;(seat as any).belongsTo(models.seat_status, { foreignKey: { name: 'seatStatus', allowNull: false }})
-  };
+    ;(seat as any).belongsTo(models.user, { foreignKey: { name: 'userId', allowNull: false } })
+    ;(seat as any).belongsTo(models.seat_status, { foreignKey: { name: 'seatStatus', allowNull: false } })
+  }
 
-  return seat;
+  return seat
 }

--- a/src/models/seat.model.ts
+++ b/src/models/seat.model.ts
@@ -1,0 +1,28 @@
+// See http://docs.sequelizejs.com/en/latest/docs/models-definition/
+// for more of what you can do here.
+import { Sequelize, DataTypes } from 'sequelize';
+import { Application } from '../declarations';
+
+export default function (app: Application) {
+  const sequelizeClient: Sequelize = app.get('sequelizeClient');
+  const seat = sequelizeClient.define('seat', {
+    
+  }, {
+    hooks: {
+      beforeCount(options: any) {
+        options.raw = true;
+      }
+    }
+  });
+
+  // eslint-disable-next-line no-unused-vars
+  (seat as any).associate = function (models: any) {
+    // Define associations here
+    // See http://docs.sequelizejs.com/en/latest/docs/associations/
+    (seat as any).belongsTo(models.subscription, { foreignKey: { name: 'subscriptionId', allowNull: false } })
+    ;(seat as any).belongsTo(models.user, { foreignKey: { name: 'userId', allowNull: false }})
+    ;(seat as any).belongsTo(models.seat_status, { foreignKey: { name: 'seatStatus', allowNull: false }})
+  };
+
+  return seat;
+}

--- a/src/models/subscription.model.ts
+++ b/src/models/subscription.model.ts
@@ -33,6 +33,18 @@ export default (app: Application): any => {
       status: {
         type: DataTypes.BOOLEAN,
         defaultValue: false
+      },
+      totalSeats: {
+          type: DataTypes.INTEGER
+      },
+      unusedSeats: {
+          type: DataTypes.INTEGER
+      },
+      pendingSeats: {
+          type: DataTypes.INTEGER
+      },
+      filledSeats: {
+          type: DataTypes.INTEGER
       }
     },
     {
@@ -48,7 +60,8 @@ export default (app: Application): any => {
   (subscription as any).associate = (models: any) => {
     // Define associations here
     (subscription as any).belongsTo(models.user);
-    (subscription as any).belongsTo(models.subscription_type, { foreignKey: 'plan', required: true })
+    (subscription as any).belongsTo(models.subscription_type, { foreignKey: 'plan', required: true });
+    (subscription as any).hasMany(models.seat, { foreignKey: 'subscriptionId' })
   }
 
   return subscription

--- a/src/models/subscription.model.ts
+++ b/src/models/subscription.model.ts
@@ -35,16 +35,16 @@ export default (app: Application): any => {
         defaultValue: false
       },
       totalSeats: {
-          type: DataTypes.INTEGER
+        type: DataTypes.INTEGER
       },
       unusedSeats: {
-          type: DataTypes.INTEGER
+        type: DataTypes.INTEGER
       },
       pendingSeats: {
-          type: DataTypes.INTEGER
+        type: DataTypes.INTEGER
       },
       filledSeats: {
-          type: DataTypes.INTEGER
+        type: DataTypes.INTEGER
       }
     },
     {

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -50,6 +50,7 @@ export default (app: Application): any => {
     (User as any).hasMany(models.owned_file, { foreignKey: 'account_id' });
     (User as any).hasMany(models.subscription)
     // (User as any).hasMany(models.conversation, { foreignKey: 'sender_id' })
+    ;(User as any).hasOne(models.seat, { foreignKey: 'userId'})
   }
 
   return User

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -50,7 +50,7 @@ export default (app: Application): any => {
     (User as any).hasMany(models.owned_file, { foreignKey: 'account_id' });
     (User as any).hasMany(models.subscription)
     // (User as any).hasMany(models.conversation, { foreignKey: 'sender_id' })
-    ;(User as any).hasOne(models.seat, { foreignKey: 'userId'})
+    ;(User as any).hasOne(models.seat, { foreignKey: 'userId' })
   }
 
   return User

--- a/src/seeder-config.ts
+++ b/src/seeder-config.ts
@@ -6,6 +6,7 @@ import EntityTypeSeed from './services/entity-type/entity-type.seed'
 import GroupUserRankSeed from './services/group-user-rank/group-user-rank.seed'
 import IdentityProviderTypeSeed from './services/identity-provider-type/identity-provider-type.seed'
 import ResourceTypeSeed from './services/resource-type/resource-type.seed'
+import SeatStatusSeed from './services/seat-status/seat-status.seed'
 import StaticResourceTypeSeed from './services/static-resource-type/static-resource-type.seed'
 import SubscriptionLevelSeed from './services/subscription-level/subscription-level.seed'
 import SubscriptionTypeSeed from './services/subscription-type/subscription-type.seed'
@@ -22,6 +23,7 @@ module.exports = {
     GroupUserRankSeed,
     IdentityProviderTypeSeed,
     ResourceTypeSeed,
+    SeatStatusSeed,
     StaticResourceTypeSeed,
     SubscriptionLevelSeed,
     SubscriptionTypeSeed,

--- a/src/services/auth-management/auth-management.utils.ts
+++ b/src/services/auth-management/auth-management.utils.ts
@@ -2,8 +2,8 @@ import { Params } from '@feathersjs/feathers'
 import { Application } from '../../declarations'
 import config from 'config'
 
-export function getLink (type: string, hash: string): string {
-  return (process.env.APP_HOST ?? '') + 'magicLink' + `?type=${type}&token=${hash}`
+export function getLink (type: string, hash: string, subscriptionId?: string): string {
+  return subscriptionId != null && subscriptionId.length > 0 ? (process.env.APP_HOST ?? '') + 'magicLink' + `?type=${type}&token=${hash}&subscriptionId=${subscriptionId}` : (process.env.APP_HOST ?? '') + 'magicLink' + `?type=${type}&token=${hash}`
 }
 
 export async function sendEmail (app: Application, email: any): Promise<void> {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -28,7 +28,7 @@ import License from './license/license.service'
 import Location from './location/location.service'
 import Party from './party/party.service'
 import Project from './project/project.service'
-import Seat from './seat/seat.service';
+import Seat from './seat/seat.service'
 import StaticResource from './static-resource/static-resource.service'
 import User from './user/user.service'
 import UserRelationship from './user-relationship/user-relationship.service'
@@ -96,7 +96,7 @@ export default (app: Application): void => {
   app.configure(License)
   app.configure(Party)
   app.configure(Project)
-  app.configure(Seat);
+  app.configure(Seat)
   app.configure(StaticResource)
   app.configure(User)
   app.configure(UserRelationship)

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -10,6 +10,7 @@ import IdentityProviderType from './identity-provider-type/identity-provider-typ
 import ResourceType from './resource-type/resource-type.service'
 import StaticResourceType from './static-resource-type/static-resource-type.service'
 import SubscriptionLevel from './subscription-level/subscription-level.service'
+import SeatStatus from './seat-status/seat-status.service'
 import UserRelationshipType from './user-relationship-type/user-relationship-type.service'
 import UserRole from './user-role/user-role.service'
 import SubscriptionType from './subscription-type/subscription-type.service'
@@ -27,6 +28,7 @@ import License from './license/license.service'
 import Location from './location/location.service'
 import Party from './party/party.service'
 import Project from './project/project.service'
+import Seat from './seat/seat.service';
 import StaticResource from './static-resource/static-resource.service'
 import User from './user/user.service'
 import UserRelationship from './user-relationship/user-relationship.service'
@@ -76,6 +78,7 @@ export default (app: Application): void => {
   app.configure(EntityType)
   app.configure(UserRelationshipType)
   app.configure(IdentityProviderType)
+  app.configure(SeatStatus)
   app.configure(SubscriptionType)
   app.configure(AccessControlScope)
   app.configure(GroupUserRank)
@@ -93,6 +96,7 @@ export default (app: Application): void => {
   app.configure(License)
   app.configure(Party)
   app.configure(Project)
+  app.configure(Seat);
   app.configure(StaticResource)
   app.configure(User)
   app.configure(UserRelationship)

--- a/src/services/seat-status/seat-status.class.ts
+++ b/src/services/seat-status/seat-status.class.ts
@@ -1,0 +1,8 @@
+import { Service, SequelizeServiceOptions } from 'feathers-sequelize';
+import { Application } from '../../declarations';
+
+export class SeatStatus extends Service {
+  constructor(options: Partial<SequelizeServiceOptions>, app: Application) {
+    super(options);
+  }
+}

--- a/src/services/seat-status/seat-status.class.ts
+++ b/src/services/seat-status/seat-status.class.ts
@@ -1,8 +1,8 @@
-import { Service, SequelizeServiceOptions } from 'feathers-sequelize';
-import { Application } from '../../declarations';
+import { Service, SequelizeServiceOptions } from 'feathers-sequelize'
+import { Application } from '../../declarations'
 
 export class SeatStatus extends Service {
-  constructor(options: Partial<SequelizeServiceOptions>, app: Application) {
-    super(options);
+  constructor (options: Partial<SequelizeServiceOptions>, app: Application) {
+    super(options)
   }
 }

--- a/src/services/seat-status/seat-status.hooks.ts
+++ b/src/services/seat-status/seat-status.hooks.ts
@@ -29,4 +29,4 @@ export default {
     patch: [],
     remove: []
   }
-};
+}

--- a/src/services/seat-status/seat-status.hooks.ts
+++ b/src/services/seat-status/seat-status.hooks.ts
@@ -1,0 +1,32 @@
+import { disallow } from 'feathers-hooks-common'
+export default {
+  before: {
+    all: [disallow('external')],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  },
+
+  after: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  },
+
+  error: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  }
+};

--- a/src/services/seat-status/seat-status.seed.ts
+++ b/src/services/seat-status/seat-status.seed.ts
@@ -5,7 +5,7 @@ export const seed = {
   randomize: false,
   templates: [
     { status: 'pending' },
-    { status: 'filled' },
+    { status: 'filled' }
   ]
 }
 

--- a/src/services/seat-status/seat-status.seed.ts
+++ b/src/services/seat-status/seat-status.seed.ts
@@ -1,0 +1,12 @@
+export const seed = {
+  disabled: (process.env.FORCE_DB_REFRESH !== 'true'),
+  delete: (process.env.FORCE_DB_REFRESH === 'true'),
+  path: 'seat-status',
+  randomize: false,
+  templates: [
+    { status: 'pending' },
+    { status: 'filled' },
+  ]
+}
+
+export default seed

--- a/src/services/seat-status/seat-status.service.ts
+++ b/src/services/seat-status/seat-status.service.ts
@@ -1,0 +1,29 @@
+// Initializes the `seat-status` service on path `/seat-status`
+import { ServiceAddons } from '@feathersjs/feathers';
+import { Application } from '../../declarations';
+import { SeatStatus } from './seat-status.class';
+import createModel from '../../models/seat-status.model';
+import hooks from './seat-status.hooks';
+
+// Add this service to the service type index
+declare module '../../declarations' {
+  interface ServiceTypes {
+    'seat-status': SeatStatus & ServiceAddons<any>;
+  }
+}
+
+export default function (app: Application) {
+  const options = {
+    Model: createModel(app),
+    paginate: app.get('paginate'),
+    multi: true
+  };
+
+  // Initialize our service with any options it requires
+  app.use('/seat-status', new SeatStatus(options, app));
+
+  // Get our initialized service so that we can register hooks
+  const service = app.service('seat-status');
+
+  service.hooks(hooks);
+}

--- a/src/services/seat-status/seat-status.service.ts
+++ b/src/services/seat-status/seat-status.service.ts
@@ -1,29 +1,29 @@
 // Initializes the `seat-status` service on path `/seat-status`
-import { ServiceAddons } from '@feathersjs/feathers';
-import { Application } from '../../declarations';
-import { SeatStatus } from './seat-status.class';
-import createModel from '../../models/seat-status.model';
-import hooks from './seat-status.hooks';
+import { ServiceAddons } from '@feathersjs/feathers'
+import { Application } from '../../declarations'
+import { SeatStatus } from './seat-status.class'
+import createModel from '../../models/seat-status.model'
+import hooks from './seat-status.hooks'
 
 // Add this service to the service type index
 declare module '../../declarations' {
   interface ServiceTypes {
-    'seat-status': SeatStatus & ServiceAddons<any>;
+    'seat-status': SeatStatus & ServiceAddons<any>
   }
 }
 
-export default function (app: Application) {
+export default function (app: Application): any {
   const options = {
     Model: createModel(app),
     paginate: app.get('paginate'),
     multi: true
-  };
+  }
 
   // Initialize our service with any options it requires
-  app.use('/seat-status', new SeatStatus(options, app));
+  app.use('/seat-status', new SeatStatus(options, app))
 
   // Get our initialized service so that we can register hooks
-  const service = app.service('seat-status');
+  const service = app.service('seat-status')
 
-  service.hooks(hooks);
+  service.hooks(hooks)
 }

--- a/src/services/seat/seat.class.ts
+++ b/src/services/seat/seat.class.ts
@@ -1,7 +1,7 @@
 import { Service, SequelizeServiceOptions } from 'feathers-sequelize'
 import { Params } from '@feathersjs/feathers'
 import { Application } from '../../declarations'
-import { BadRequest } from '@feathersjs/errors'
+import { BadRequest, NotFound } from '@feathersjs/errors'
 import app from './../../app'
 
 export class Seat extends Service {
@@ -13,13 +13,10 @@ export class Seat extends Service {
 
   // prettier-ignore
   async create (data: any, params?: Params): Promise<any> {
-    console.log('SEAT CREATION')
     const userId = (params as any).userId || (params as any).connection['identity-provider'].userId
     if (userId == null) {
       throw new Error('Invalid user')
     }
-
-    console.log(userId)
     const subscription = await app.service('subscription').find({
       query: {
         status: true,
@@ -30,27 +27,21 @@ export class Seat extends Service {
     if ((subscription as any).total === 0) {
       throw new BadRequest('Not signed up for a subscription')
     }
-
-    console.log(subscription)
     const { totalSeats, unusedSeats, filledSeats, pendingSeats } = (subscription as any).data[0]
 
-    if (unusedSeats === 0 || filledSeats + pendingSeats === totalSeats) {
+    if (unusedSeats === 0 || (filledSeats as number) + (pendingSeats as number) === totalSeats) {
       throw new BadRequest('All available seats filled or pending')
     }
 
     if ((params as any).self === true) {
-      console.log('Setting self seat')
-      let existingSelfSeat = await super.find({
+      const existingSelfSeat = await super.find({
         query: {
           subscriptionId: data.subscriptionId,
-          userId: userId,
+          userId: userId
         }
       })
-
-      console.log(existingSelfSeat)
-
       if ((existingSelfSeat as any).total > 0) {
-        await Promise.all((existingSelfSeat as any).data.map((seat: any) => { return super.remove(seat.id)}))
+        await Promise.all((existingSelfSeat as any).data.map((seat: any) => { return super.remove(seat.id) }))
       }
       await super.create({
         subscriptionId: data.subscriptionId,
@@ -59,25 +50,90 @@ export class Seat extends Service {
       })
 
       await app.service('subscription').patch(data.subscriptionId, {
-        unusedSeats: unusedSeats - 1,
-        filledSeats: filledSeats + 1
+        unusedSeats: (unusedSeats as number) - 1,
+        filledSeats: (filledSeats as number) + 1
       })
-      return
-    }
-    else {
+    } else {
+      const identityProvider = await app.service('identity-provider').find({
+        query: {
+          type: 'email',
+          token: data.email
+        }
+      })
+      const existingUserInSeat = (identityProvider as any).total > 0 ? await app.service('seat').find({
+        query: {
+          userId: (identityProvider as any).data[0].userId
+        }
+      }) : { total: 0 }
+      if ((existingUserInSeat as any).total > 0) {
+        throw new BadRequest('User already has a seat')
+      }
+
       const link = await app.service('magiclink').create({
         type: 'email',
         email: data.email,
         subscriptionId: data.subscriptionId
       })
-
-      console.log(link)
-
-      return await super.create({
+      const newIdentityProvider = await app.service('identity-provider').find({
+        query: {
+          type: (link as any).type,
+          token: (link as any).email
+        }
+      })
+      if ((newIdentityProvider as any).total === 0) {
+        throw new BadRequest('Invalid email address')
+      }
+      const seat = await super.create({
         subscriptionId: data.subscriptionId,
-        userId: (link as any).userId,
+        userId: (newIdentityProvider as any).data[0].userId,
         seatStatus: 'pending'
       })
+
+      await app.service('subscription').patch(data.subscriptionId, {
+        unusedSeats: (unusedSeats as number) - 1,
+        pendingSeats: (pendingSeats as number) + 1
+      })
+      return seat
     }
+  }
+
+  async patch (id: string, data: any, params?: Params): Promise<any> {
+    const subscriptionId = data.subscriptionId as string
+    const subscription = await app.service('subscription').get(subscriptionId)
+    if (subscription == null) {
+      console.log('Attempt to patch subscription ' + subscriptionId + ' failed because that is not a valid subscription')
+      throw new NotFound()
+    }
+    const seatResult = await super.find({
+      query: {
+        userId: id
+      }
+    })
+    if ((seatResult as any).total === 0) {
+      console.log('Attempt to patch user ' + id + ' into subscription ' + subscriptionId + ' failed because that user does not have a seat there.')
+      throw new NotFound()
+    }
+
+    if ((seatResult as any).total > 1) {
+      console.log('User has too many seats somehow')
+      throw new BadRequest('User has too many seats')
+    }
+
+    const seat = (seatResult as any).data[0]
+    if (seat.subscriptionId !== subscriptionId) {
+      throw new BadRequest('User does not have a seat on that subscription')
+    }
+    if (seat.seatStatus === 'pending') {
+      await super.patch(seat.id, {
+        seatStatus: 'filled'
+      })
+
+      await app.service('subscription').patch(subscription.id, {
+        pendingSeats: (subscription.pendingSeats as number) - 1,
+        filledSeats: (subscription.pendingSeats as number) + 1
+      })
+    }
+
+    return seat
   }
 }

--- a/src/services/seat/seat.class.ts
+++ b/src/services/seat/seat.class.ts
@@ -1,0 +1,83 @@
+import { Service, SequelizeServiceOptions } from 'feathers-sequelize'
+import { Params } from '@feathersjs/feathers'
+import { Application } from '../../declarations'
+import { BadRequest } from '@feathersjs/errors'
+import app from './../../app'
+
+export class Seat extends Service {
+  // prettier-ignore
+  // prettier-ignore
+  constructor (options: Partial<SequelizeServiceOptions>, app: Application) {
+    super(options)
+  }
+
+  // prettier-ignore
+  async create (data: any, params?: Params): Promise<any> {
+    console.log('SEAT CREATION')
+    const userId = (params as any).userId || (params as any).connection['identity-provider'].userId
+    if (userId == null) {
+      throw new Error('Invalid user')
+    }
+
+    console.log(userId)
+    const subscription = await app.service('subscription').find({
+      query: {
+        status: true,
+        userId: userId
+      }
+    })
+
+    if ((subscription as any).total === 0) {
+      throw new BadRequest('Not signed up for a subscription')
+    }
+
+    console.log(subscription)
+    const { totalSeats, unusedSeats, filledSeats, pendingSeats } = (subscription as any).data[0]
+
+    if (unusedSeats === 0 || filledSeats + pendingSeats === totalSeats) {
+      throw new BadRequest('All available seats filled or pending')
+    }
+
+    if ((params as any).self === true) {
+      console.log('Setting self seat')
+      let existingSelfSeat = await super.find({
+        query: {
+          subscriptionId: data.subscriptionId,
+          userId: userId,
+        }
+      })
+
+      console.log(existingSelfSeat)
+
+      if ((existingSelfSeat as any).total > 0) {
+        await Promise.all((existingSelfSeat as any).data.map((seat: any) => { return super.remove(seat.id)}))
+      }
+      await super.create({
+        subscriptionId: data.subscriptionId,
+        userId: userId,
+        seatStatus: 'filled'
+      })
+
+      await app.service('subscription').patch(data.subscriptionId, {
+        unusedSeats: unusedSeats - 1,
+        filledSeats: filledSeats + 1
+      })
+      return
+    }
+    else {
+      const link = await app.service('magiclink').create({
+        type: 'email',
+        email: data.email,
+        subscriptionId: data.subscriptionId
+      })
+
+      console.log(link)
+
+      return await super.create({
+        subscriptionId: data.subscriptionId,
+        userId: (link as any).userId,
+        seatStatus: 'pending'
+      })
+    }
+  }
+}

--- a/src/services/seat/seat.hooks.ts
+++ b/src/services/seat/seat.hooks.ts
@@ -1,0 +1,36 @@
+import * as authentication from '@feathersjs/authentication';
+// Don't remove this comment. It's needed to format import lines nicely.
+
+const { authenticate } = authentication.hooks;
+
+export default {
+  before: {
+    all: [ authenticate('jwt') ],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  },
+
+  after: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  },
+
+  error: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  }
+};

--- a/src/services/seat/seat.hooks.ts
+++ b/src/services/seat/seat.hooks.ts
@@ -1,27 +1,109 @@
-import * as authentication from '@feathersjs/authentication';
+import * as authentication from '@feathersjs/authentication'
+import { HookContext } from '@feathersjs/feathers'
+import { BadRequest, NotFound } from '@feathersjs/errors'
+import * as commonHooks from 'feathers-hooks-common'
 // Don't remove this comment. It's needed to format import lines nicely.
 
-const { authenticate } = authentication.hooks;
+const { authenticate } = authentication.hooks
 
 export default {
   before: {
-    all: [ authenticate('jwt') ],
-    find: [],
+    all: [authenticate('jwt')],
+    find: [
+      commonHooks.iff(
+        commonHooks.isProvider('external'),
+        async (context: HookContext) => {
+          const { app, params } = context
+
+          const ownedSubscription = await app.service('subscription').find({
+            query: {
+              userId: params['identity-provider']?.userId || (params as any).query.connection['identity-provider'].userId
+            }
+          })
+          if ((ownedSubscription).total === 0) {
+            throw new BadRequest('NO SUBSCRIPTION')
+          }
+          (params as any).query.subscriptionId = ownedSubscription.data[0].id
+          return context
+        }
+      )
+    ],
     get: [],
     create: [],
     update: [],
     patch: [],
-    remove: []
+    remove: [async (context: HookContext) => {
+      const { app, id, params } = context
+
+      const ownedSubscription = await app.service('subscription').find({
+        query: {
+          userId: params['identity-provider']?.userId || (params as any).query.connection['identity-provider'].userId
+        }
+      })
+      if ((ownedSubscription).total === 0) {
+        throw new BadRequest('NO SUBSCRIPTION')
+      }
+      const seatResult = await app.service('seat').get(id)
+      if (seatResult == null) {
+        throw new NotFound()
+      }
+      if (seatResult.subscriptionId !== ownedSubscription.data[0].id) {
+        throw new NotFound()
+      }
+      params.removedSeat = seatResult
+      params.ownedSubscription = ownedSubscription.data[0]
+      return context
+    }]
   },
 
   after: {
     all: [],
-    find: [],
+    find: [
+      async (context: HookContext) => {
+        const { app, result } = context
+        await Promise.all(result.data.map(async (seat: any) => {
+          const user = await app.service('user').get(seat.userId)
+          const identityProviderResult = await app.service('identity-provider').find({
+            query: {
+              type: 'email',
+              userId: seat.userId
+            }
+          })
+          if (user != null) {
+            seat.user = {
+              name: user.name
+            }
+          }
+          if (identityProviderResult.total > 0) {
+            seat.user = {
+              ...seat.user,
+              email: (identityProviderResult).data[0].token
+            }
+          }
+        }))
+        return context
+      }
+    ],
     get: [],
     create: [],
     update: [],
     patch: [],
-    remove: []
+    remove: [
+      async (context: HookContext) => {
+        const { app, params } = context
+        const ownedSubscription = (params as any).ownedSubscription
+        const update = {
+          unusedSeats: (ownedSubscription.unusedSeats as number) + 1
+        }
+        if ((params as any).removedSeat.seatStatus === 'pending') {
+          (update as any).pendingSeats = ownedSubscription.pendingSeats - 1
+        } else if ((params as any).removedSeat.seatStatus === 'filled') {
+          (update as any).filledSeats = ownedSubscription.filledSeats - 1
+        }
+        await app.service('subscription').patch(ownedSubscription.id, update)
+        return context
+      }
+    ]
   },
 
   error: {
@@ -33,4 +115,4 @@ export default {
     patch: [],
     remove: []
   }
-};
+}

--- a/src/services/seat/seat.service.ts
+++ b/src/services/seat/seat.service.ts
@@ -1,0 +1,28 @@
+// Initializes the `seat` service on path `/seat`
+import { ServiceAddons } from '@feathersjs/feathers';
+import { Application } from '../../declarations';
+import { Seat } from './seat.class';
+import createModel from '../../models/seat.model';
+import hooks from './seat.hooks';
+
+// Add this service to the service type index
+declare module '../../declarations' {
+  interface ServiceTypes {
+    'seat': Seat & ServiceAddons<any>;
+  }
+}
+
+export default function (app: Application) {
+  const options = {
+    Model: createModel(app),
+    paginate: app.get('paginate')
+  };
+
+  // Initialize our service with any options it requires
+  app.use('/seat', new Seat(options, app));
+
+  // Get our initialized service so that we can register hooks
+  const service = app.service('seat');
+
+  service.hooks(hooks);
+}

--- a/src/services/seat/seat.service.ts
+++ b/src/services/seat/seat.service.ts
@@ -1,28 +1,28 @@
 // Initializes the `seat` service on path `/seat`
-import { ServiceAddons } from '@feathersjs/feathers';
-import { Application } from '../../declarations';
-import { Seat } from './seat.class';
-import createModel from '../../models/seat.model';
-import hooks from './seat.hooks';
+import { ServiceAddons } from '@feathersjs/feathers'
+import { Application } from '../../declarations'
+import { Seat } from './seat.class'
+import createModel from '../../models/seat.model'
+import hooks from './seat.hooks'
 
 // Add this service to the service type index
 declare module '../../declarations' {
   interface ServiceTypes {
-    'seat': Seat & ServiceAddons<any>;
+    'seat': Seat & ServiceAddons<any>
   }
 }
 
-export default function (app: Application) {
+export default function (app: Application): any {
   const options = {
     Model: createModel(app),
     paginate: app.get('paginate')
-  };
+  }
 
   // Initialize our service with any options it requires
-  app.use('/seat', new Seat(options, app));
+  app.use('/seat', new Seat(options, app))
 
   // Get our initialized service so that we can register hooks
-  const service = app.service('seat');
+  const service = app.service('seat')
 
-  service.hooks(hooks);
+  service.hooks(hooks)
 }

--- a/src/services/subscription-confirm/subscription-confirm.class.ts
+++ b/src/services/subscription-confirm/subscription-confirm.class.ts
@@ -34,7 +34,7 @@ export class SubscriptionConfirm implements ServiceMethods<Data> {
       const subscription = (subscriptionResult as any).data[0]
       console.log(subscription)
       console.log('Getting subscription-type')
-      const subscriptionType = await app.service('subscription-type').get((subscription as any).plan)
+      const subscriptionType = await app.service('subscription-type').get((subscription).plan)
       console.log(subscriptionType)
       await app.service('subscription').patch(id, {
         status: 1,
@@ -46,7 +46,7 @@ export class SubscriptionConfirm implements ServiceMethods<Data> {
 
       console.log('PATCHED SUBSCRIPTION')
       await app.service('seat').create({
-        subscriptionId: (subscription as any).id
+        subscriptionId: (subscription).id
       }, {
         self: true,
         userId: userId

--- a/test/services/seat-status.test.ts
+++ b/test/services/seat-status.test.ts
@@ -1,0 +1,10 @@
+import assert from 'assert';
+import app from '../../src/app';
+
+describe('\'seat-status\' service', () => {
+  it('registered the service', () => {
+    const service = app.service('seat-status');
+
+    assert.ok(service, 'Registered the service');
+  });
+});

--- a/test/services/seat-status.test.ts
+++ b/test/services/seat-status.test.ts
@@ -1,10 +1,10 @@
-import assert from 'assert';
-import app from '../../src/app';
+import assert from 'assert'
+import app from '../../src/app'
 
 describe('\'seat-status\' service', () => {
   it('registered the service', () => {
-    const service = app.service('seat-status');
+    const service = app.service('seat-status')
 
-    assert.ok(service, 'Registered the service');
-  });
-});
+    assert.ok(service, 'Registered the service')
+  })
+})

--- a/test/services/seat.test.ts
+++ b/test/services/seat.test.ts
@@ -1,10 +1,10 @@
-import assert from 'assert';
-import app from '../../src/app';
+import assert from 'assert'
+import app from '../../src/app'
 
-describe('\'seats\' service', () => {
+describe('\'seat\' service', () => {
   it('registered the service', () => {
-    const service = app.service('seats');
+    const service = app.service('seat')
 
-    assert.ok(service, 'Registered the service');
-  });
-});
+    assert.ok(service, 'Registered the service')
+  })
+})

--- a/test/services/seat.test.ts
+++ b/test/services/seat.test.ts
@@ -1,0 +1,10 @@
+import assert from 'assert';
+import app from '../../src/app';
+
+describe('\'seats\' service', () => {
+  it('registered the service', () => {
+    const service = app.service('seats');
+
+    assert.ok(service, 'Registered the service');
+  });
+});


### PR DESCRIPTION
**What is the purpose of this PR?**
Implement seats for a subscription.

**What does issue #s are solved by this PR?**
No specific issues

**What unit tests have been put in place?**
None

**What files or features are including in this PR that are not related to the main feature?**
None

**How does our QA team test this PR?**
This is most easily tested with the client branch 'seats'.

Login with a user, then sign up for a plan. It's best to sign up for something above 'Journey', as that only has one seat.

Subscriptions now have four new column: totalSeats, unusedSeats, pendingSeats, and filledSeats. Respectively, they are: the number of seats the subscription is entitled to; the number of seats that are neither pending nor filled; the number of invitations that have been sent out but not confirmed; and the number of invitations that have been confirmed (plus a seat for the owner of the subscription, which will automatically be created and cannot be removed).

Go to the Profile modal, and then go to the Subscription tab. There should now be a button 'Manage Subscription Seats'. Click that to go to /subscription/seats, a new page.

If the user has a subscription, they should see their account occupying a seat. This seat cannot be removed.

Enter an email address into the text field and either press enter or click the button next to it. This will do a magicLink login for that address - if it's already in the system, no new user/identityProvider will be created, but if it's not, a new user/email identityProvider will be made. The email that gets sent out has an additional query parameter for subscriptionId.

At this point, the email address should show up above the self user. You can press the 'Cancel Invitation' button to remove the pending seat. If you follow the login link, it should not do anything to the seat status of that subscription.

If you follow the login link when there is a pending seat for it, the user should be logged in and the pending seat should be converted to a filled seat. If you follow the link again for a user of a filled seat, nothing more seat-wise should happen.

As the subscription holder, you can revoke filled seats by pressing the button next to those users. If you've remained on the seats page the whole time and filled the seat through, say, an incognito window, you'll have to refresh the page to see the button switch from 'cancel invitation' to 'revoke seat', as the page currently isn't subscribing to any changes from the server.

NOTE:
Patching seats is a little different than expected. Since going from pending->filled is going to take place when the subscription owner isn't present, the ID for this should be the userId of the seat and the data that's passed in is just { subscriptionId: <subscriptionId> }. The server checks to see if that user has a pending seat on that subscription and converts it to filled if that's the case.