### PR TITLE
Updated authManagement.getLink to account for new APP_HOST

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -50,8 +50,8 @@ app.configure(sequelize)
 // Enable security, CORS, compression, favicon and body parsing
 app.use(helmet())
 app.use(cors({
-    origin: process.env.APP_HOST,
-    credentials: true
+  origin: process.env.APP_HOST,
+  credentials: true
 }))
 app.use(compress())
 app.use(express.json())

--- a/src/services/auth-management/auth-management.utils.ts
+++ b/src/services/auth-management/auth-management.utils.ts
@@ -3,7 +3,7 @@ import { Application } from '../../declarations'
 import config from 'config'
 
 export function getLink (type: string, hash: string, subscriptionId?: string): string {
-  return subscriptionId != null && subscriptionId.length > 0 ? (process.env.APP_HOST ?? '') + 'magicLink' + `?type=${type}&token=${hash}&subscriptionId=${subscriptionId}` : (process.env.APP_HOST ?? '') + 'magicLink' + `?type=${type}&token=${hash}`
+  return subscriptionId != null && subscriptionId.length > 0 ? (process.env.APP_HOST ?? '') + '/magicLink' + `?type=${type}&token=${hash}&subscriptionId=${subscriptionId}` : (process.env.APP_HOST ?? '') + '/magicLink' + `?type=${type}&token=${hash}`
 }
 
 export async function sendEmail (app: Application, email: any): Promise<void> {


### PR DESCRIPTION
CORS is now using APP_HOST for its origin. The client is
sending a domain that lacks a trailing slash, so APP_HOST must
also not have one. authManagement.getLink assumed there was a
trailing slash, so I added a slash before the path assuming
that APP_HOST won't have one.