### PR TITLE
Master merge 5/29/20

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -50,8 +50,8 @@ app.configure(sequelize)
 // Enable security, CORS, compression, favicon and body parsing
 app.use(helmet())
 app.use(cors({
-    origin: process.env.APP_HOST,
-    credentials: true
+  origin: process.env.APP_HOST,
+  credentials: true
 }))
 app.use(compress())
 app.use(express.json())

--- a/src/app.ts
+++ b/src/app.ts
@@ -49,7 +49,10 @@ app.configure(sequelize)
 
 // Enable security, CORS, compression, favicon and body parsing
 app.use(helmet())
-app.use(cors())
+app.use(cors({
+    origin: process.env.APP_HOST,
+    credentials: true
+}))
 app.use(compress())
 app.use(express.json())
 app.use(express.urlencoded({ extended: true }))

--- a/src/hooks/convert-video.ts
+++ b/src/hooks/convert-video.ts
@@ -18,6 +18,7 @@ import _ from 'lodash'
 // @ts-ignore
 import appRootPath from 'app-root-path'
 import uploadThumbnailLinkHook from './upload-thumbnail-link'
+import { BadRequest } from '@feathersjs/errors'
 
 const promiseExec = util.promisify(exec)
 
@@ -285,7 +286,7 @@ export default async (context: any): Promise<void> => {
 
     await app.service('static-resource').remove(result.id)
 
-    return context
+    throw new BadRequest('Invalid URL')
   }
 }
 

--- a/src/services/auth-management/auth-management.utils.ts
+++ b/src/services/auth-management/auth-management.utils.ts
@@ -3,7 +3,7 @@ import { Application } from '../../declarations'
 import config from 'config'
 
 export function getLink (type: string, hash: string, subscriptionId?: string): string {
-  return subscriptionId != null && subscriptionId.length > 0 ? (process.env.APP_HOST ?? '') + 'magicLink' + `?type=${type}&token=${hash}&subscriptionId=${subscriptionId}` : (process.env.APP_HOST ?? '') + 'magicLink' + `?type=${type}&token=${hash}`
+  return subscriptionId != null && subscriptionId.length > 0 ? (process.env.APP_HOST ?? '') + '/magicLink' + `?type=${type}&token=${hash}&subscriptionId=${subscriptionId}` : (process.env.APP_HOST ?? '') + '/magicLink' + `?type=${type}&token=${hash}`
 }
 
 export async function sendEmail (app: Application, email: any): Promise<void> {


### PR DESCRIPTION
CORS needs origin to exactly match requesting domain, which in our case lacks a trailing slash.
CORS config now using APP_HOST, which will now lack a trailing slash.
Updated auth-management.getLink to manually add trailing slash instead of expecting it on APP_HOST.